### PR TITLE
Fix repository info in package.json

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -8,7 +8,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "github.com/ProcessOut/currencies"
+        "url": "git://github.com/processout/currencies"
     },
     "keywords": [
         "iso4217",


### PR DESCRIPTION
As it's set currently is not picked by npm -> https://www.npmjs.com/package/iso-currencies